### PR TITLE
Remove remaining pixel lengths

### DIFF
--- a/xquartz.html
+++ b/xquartz.html
@@ -119,16 +119,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   .caplogo {
     vertical-align: baseline;
-    zmargin-right: -2px;
     border: 0;
     position: relative;
-    bottom: -3px;
-    height: 48px;
+    bottom: -0.1em;
+    height: 1.5em;
   }
 
   .textlogo {
     vertical-align: baseline;
-    font-size: 48px;
+    font-size: 150%;
   }
 
   .inset {
@@ -137,10 +136,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   .download-icon {
     display: inline-block;
-    width: 16px;
-    height: 16px;
+    width: 1em;
+    height: 1em;
     vertical-align: baseline;
     background-image: url(download.png);
+    background-repeat: no-repeat;
+    background-position: 0% 100%;
+    background-size: 1em 1em;
     margin-right: 2px;
   }
 


### PR DESCRIPTION
Replaced remaining hard-coded pixel lengths with relative lengths
scaling the images as appropriate.  Uses CSS3 background-size
property (widely supported) but behaves well if that's not supported.

Signed-off-by: Kyle J. McKay mackyle@gmail.com
